### PR TITLE
Make license match SPDX ID

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -11,7 +11,7 @@
 
   <maintainer email="bernd@bimstatik.org">Bernd Hahnebach</maintainer>
 
-  <license file="BOLTS/LICENSE">LGPLv2.1</license>
+  <license file="BOLTS/LICENSE">LGPL-2.1-or-later</license>
 
   <pythonmin>3.5.0</pythonmin>
 


### PR DESCRIPTION
See https://spdx.org/licenses/ -- note that you might actually mean `LGPL-2.1-only`, in which case use that instead.
